### PR TITLE
fix: 🐛 Return daysLeft as zero during vacation

### DIFF
--- a/Utils/Counter.js
+++ b/Utils/Counter.js
@@ -14,6 +14,9 @@ const lastFridayForMonth = function (monthMoment) {
 module.exports = {
     countVacation: function () {
         let now = moment().utc().local()
+        if (now.month() === 6 || now.month() === 7) {
+            return { daysTotal: 0, daysLeft: 0, procent: 1 };
+        }
         let start = moment().year(now.year()).month(8).date(1).day(8);
         if (start.date() > 7) start.day(-6);
         let end = lastFridayForMonth(moment().year(now.year() + 1).month(5));


### PR DESCRIPTION
This prevents displaying negative days left to the next vacation